### PR TITLE
Use LightInjectServiceProviderFactory

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,36 @@
+{
+   // Use IntelliSense to find out which attributes exist for C# debugging
+   // Use hover for the description of the existing attributes
+   // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+   "version": "0.2.0",
+   "configurations": [
+        {
+            "name": ".NET Core Launch (web)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/ASPNETCore30WebApp/bin/Debug/netcoreapp3.0/ASPNETCore30WebApp.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/ASPNETCore30WebApp",
+            "stopAtEntry": false,
+            // Enable launching a web browser when ASP.NET Core starts. For more information: https://aka.ms/VSCode-CS-LaunchJson-WebBrowser
+            "serverReadyAction": {
+                "action": "openExternally",
+                "pattern": "^\\s*Now listening on:\\s+(https?://\\S+)"                
+            },
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            },
+            "sourceFileMap": {
+                "/Views": "${workspaceFolder}/Views"
+            }
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,42 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/ASPNETCore30WebApp/ASPNETCore30WebApp.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/ASPNETCore30WebApp/ASPNETCore30WebApp.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "${workspaceFolder}/ASPNETCore30WebApp/ASPNETCore30WebApp.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/ASPNETCore30WebApp/CompositionRoot.cs
+++ b/ASPNETCore30WebApp/CompositionRoot.cs
@@ -7,7 +7,9 @@ namespace ASPNETCore30WebApp
     {
         public void Compose(IServiceRegistry serviceRegistry)
         {
-            serviceRegistry.Register<IThing, Thing>(new PerRequestLifeTime());
+            // You probably want PerScopeLifeTime here.
+            // http://www.lightinject.net/#scope
+            serviceRegistry.Register<IThing, Thing>(new PerScopeLifetime());
         }
     }
 

--- a/ASPNETCore30WebApp/Program.cs
+++ b/ASPNETCore30WebApp/Program.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using LightInject;
 using LightInject.Microsoft.AspNetCore.Hosting;
+using LightInject.Microsoft.DependencyInjection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
@@ -22,8 +23,8 @@ namespace ASPNETCore30WebApp
             Host.CreateDefaultBuilder(args)
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
-                    webBuilder.UseLightInject(ContainerOptions.Default.WithAspNetCoreSettings());
                     webBuilder.UseStartup<Startup>();
-                });
+                })
+                .UseServiceProviderFactory(new LightInjectServiceProviderFactory());
     }
 }


### PR DESCRIPTION
Changed the Program.cs ever so slightly to use the `LightInjectServiceProviderFactory`.

When .Net Core ships there will be a package for generic host. Something like `LightInject.Microsoft.Hosting`